### PR TITLE
feat(BREAKING): prune 1 by default instead of all

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ ipfs-cohost sync
 
 ### Prune
 
-Delete all snapshots but the last `n`. If `n` is not provided, all snapshots will be deleted.
+Delete all snapshots but the last `n`. If `n` is not provided, all snapshots but the last one will be deleted.
 
 ```console
 $ ipfs-cohost prune [n]

--- a/bin.js
+++ b/bin.js
@@ -111,7 +111,7 @@ function printSnapshots (snap) {
 }
 
 async function prune (ipfs, input) {
-  let num = null
+  let num = 1
   if (input.length > 0) num = parseInt(input[0], 10)
 
   const spinner = spin('Cleaning cohosted websites...')

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ async function pruneHelper (ipfs, keep, domains, type) {
   for (const domain of domains) {
     const snapshots = (await ls(ipfs, domain))[type].sort()
 
-    if (keep !== null) {
+    if (keep !== 0) {
       const toRemove = snapshots.reverse().slice(keep)
       for (const snap of toRemove) {
         await ipfs.files.rm(`/cohosting/${type}/${domain}/${snap}`, { recursive: true })
@@ -142,8 +142,12 @@ async function pruneHelper (ipfs, keep, domains, type) {
   return removed
 }
 
-async function prune (ipfs, keep = null) {
+async function prune (ipfs, keep) {
   const { lazy, full } = await ls(ipfs)
+
+  if (typeof keep !== 'number') {
+    throw new Error('keep must be a number')
+  }
 
   return {
     lazy: await pruneHelper(ipfs, keep, lazy, 'lazy'),


### PR DESCRIPTION
Addresses part of #13 by making `1` the default value for the `prune` subcommand.

Closes #13.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>