### PR TITLE
feat: add rm --all flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ $ ipfs-cohost rm ipfs.io docs.ipfs.io awesome.ipfs.io
 ✔  awesome.ipfs.io no longer cohosted.
 ```
 
+You can also remove every website you have cohosted:
+
+```console
+$ ipfs-cohost rm --all
+🔌 Using local ipfs daemon via http api
+✔ All cohosted websites removed.
+```
+
 ### List cohosted websites and snapshots
 
 Use `ls` with no arguments to list the cohosted domains:

--- a/bin.js
+++ b/bin.js
@@ -13,7 +13,7 @@ const cli = meow(`
   Usage
     $ ipfs-cohost <domain>...
     $ ipfs-cohost add <domain>... [--lazy] [--full]
-    $ ipfs-cohost rm <domain>...
+    $ ipfs-cohost rm <domain>... [--all]
     $ ipfs-cohost ls [domain]...
     $ ipfs-cohost mv [domain]... [--lazy] [--full]
     $ ipfs-cohost sync
@@ -38,6 +38,9 @@ const cli = meow(`
     },
     lazy: {
       type: 'boolean'
+    },
+    all: {
+      type: 'boolean'
     }
   }
 })
@@ -60,6 +63,14 @@ async function add (ipfs, input) {
 
 async function rm (ipfs, input) {
   let spinner
+
+  if (cli.flags.all) {
+    spinner = spin('Removing all cohosted websites...')
+    await cohost.rmAll(ipfs)
+    spinner.succeed('All cohosted websites removed.')
+    return
+  }
+
   for (const domain of input) {
     spinner = spin(`Stopping to cohost ${domain}...`)
     await cohost.rm(ipfs, domain)

--- a/bin.js
+++ b/bin.js
@@ -26,6 +26,7 @@ const cli = meow(`
     --silent, -s  Just do your job
     --full        Fully cohost a website
     --lazy        Lazily cohost a website (default)
+    --all         Remove all cohosted websites (lazy AND full)
 `, {
   flags: {
     silent: {

--- a/index.js
+++ b/index.js
@@ -80,6 +80,10 @@ async function rm (ipfs, domain) {
   }
 }
 
+async function rmAll (ipfs) {
+  await ipfs.files.rm('/cohosting', { recursive: true })
+}
+
 async function ls (ipfs, domain = null) {
   let lazyPath = '/cohosting/lazy'
   let fullPath = '/cohosting/full'
@@ -168,6 +172,7 @@ async function mv (ipfs, domain, opts) {
 module.exports = {
   add,
   rm,
+  rmAll,
   ls,
   sync,
   prune,


### PR DESCRIPTION
Adds support for `--all` flag in `rm` command which simply deletes everything.

Cc #13.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>