### PR TITLE
feat(BREAKING): remove js-ipfs

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -189,10 +189,7 @@ async function run () {
 function getIpfs () {
   return ipfsProvider({
     tryWebExt: false,
-    tryWindow: false,
-    tryJsIpfs: true,
-    getJsIpfs: () => require('ipfs'),
-    jsIpfsOpts: { silent: true }
+    tryWindow: false
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "author": "olizilla",
   "license": "MIT",
   "dependencies": {
-    "ipfs": "^0.38.1",
     "ipfs-provider": "^0.2.2",
     "meow": "^5.0.0",
     "ora": "^4.0.2",


### PR DESCRIPTION
Closes #6. This removes `js-ipfs`. I decided to do this PR because of the following thought: why would someone not have a repository and wants to cohost a website? It basically serves nothing if they don't have IPFS itself on their machine. They wouldn't be able to access it until they later installed IPFS somehow.

Also, reduces `npx` overhead and basic use CLI.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>