### PR TITLE
feat: latest subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ $ ipfs-cohost prune [n]
 ✔  Cohosted websites cleaned!
 ```
 
+### Only add latest copies
+
+In some situations, you might want to be able to provide a strict list of domains you want to have one and only snapshot per domain. You can use `ipfs-cohost latest <domain>...` as a short hand for `ipfs-cohost rm --all && ipfs-cohost add <domain>...`. All flags apply.
+
 ### Could you do these with a few lines of bash?
 
 Yes. All of this commands can be reproducible via bash commands. Please take a look at the [cohosting SPEC](https://github.com/ipfs-shipyard/cohosting/blob/master/SPEC.md) to know which `ipfs` commands are equivalent to these ones.

--- a/bin.js
+++ b/bin.js
@@ -19,6 +19,7 @@ const cli = meow(`
     $ ipfs-cohost mv [domain]... [--lazy] [--full]
     $ ipfs-cohost sync
     $ ipfs-cohost prune [n]
+    $ ipfs-cohost latest <domain>... [--lazy] [--full]
 
   Example
     $ ipfs-cohost docs.ipfs.io cid.ipfs.io
@@ -177,6 +178,12 @@ async function mv (ipfs, input) {
   }
 }
 
+async function latest (ipfs, input) {
+  cli.flags.all = true
+  await rm(ipfs)
+  await add(ipfs, input)
+}
+
 async function run () {
   if (cli.input.length === 0) {
     return cli.showHelp()
@@ -212,6 +219,9 @@ async function run () {
         break
       case 'mv':
         await mv(ipfs, input)
+        break
+      case 'latest':
+        await latest(ipfs, input)
         break
       default:
         await add(ipfs, input.concat(cmd))


### PR DESCRIPTION
Depends on #16. This adds a latest sub-command which is a short-hand for `rm --all && add <domains>...` where all flags apply.

We probably should also ignore, in this case, `non-interactive`. @lidel @olizilla?